### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ Should probably add the newly built manual::
 Next, change to the gh-pages repo dir and commit the stuff that the ``make
 html`` command made::
 
-    cd ../sphinxdoc-test-docs
+    cd ../sphinxdoc-test-docs/html
     git add .
     git commit -m "rebuilt docs"
 


### PR DESCRIPTION
The current file shows that you should goto ../sphinxdoc-test-docs and then do a "git add .", however, that is incorrect, you have to goto ../sphinxdoc-test-docs/html and then "git add ." from there. Please update the same.

Regards,
Mohit
